### PR TITLE
add support for scala 2.12 and akka-http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: scala
 
 scala:
-  - 2.11.2
+  - 2.11.8
+  - 2.12.0
 
 branches:
   only:
@@ -13,4 +14,4 @@ notifications:
       - jorgevc@fastmail.es
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ import xmlrpc.Xmlrpc._
 If you don't have an Actor System in scope or you don't have an environment created for Spray, you must set it up:
 ```scala
 implicit val system = ActorSystem()
+implicit val ma = ActorMaterializer()
 implicit val timeout = Timeout(5 seconds)
 import system.dispatcher
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 name := "xmlrpc"
 
-version := "1.1"
+version := "1.2-SNAPSHOT"
 
 description := "Module that gives full compatibility with XML-RPC for Scala"
 
 organization := "com.github.jvican"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.12.0"
+
+crossScalaVersions := Seq("2.11.8", "2.12.0")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -14,20 +16,16 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= {
-  val scalazVersion = "7.1.3"
-  val akkaVersion = "2.3.9"
-  val sprayVersion = "1.3.3"
-  val scalaTestVersion = "2.2.4"
-  val shapelessVersion = "2.2.3"
+  val scalazVersion = "7.2.7"
+  val akkaHttp = "10.0.0-RC2"
+  val scalaTestVersion = "3.0.1"
+  val shapelessVersion = "2.3.2"
 
   Seq(
-    "org.scalaz"        %% "scalaz-core"    % scalazVersion,
-    "io.spray"          %% "spray-http"     % sprayVersion,
-    "io.spray"          %% "spray-can"      % sprayVersion,
-    "io.spray"          %% "spray-client"   % sprayVersion,
-    "com.typesafe.akka" %% "akka-actor"     % akkaVersion,
-    "org.scalatest"     %% "scalatest"      % scalaTestVersion    % "test",
-    "com.chuusai"       %% "shapeless"      % shapelessVersion
+    "org.scalaz"             %% "scalaz-core"    % scalazVersion,
+    "com.typesafe.akka"      %% "akka-http-xml"  % akkaHttp,
+    "org.scalatest"          %% "scalatest"      % scalaTestVersion    % "test",
+    "com.chuusai"            %% "shapeless"      % shapelessVersion
   )
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.13

--- a/src/main/scala/xmlrpc/XmlrpcResponse.scala
+++ b/src/main/scala/xmlrpc/XmlrpcResponse.scala
@@ -24,7 +24,7 @@ case class XmlrpcResponse[R](underlying: Future[Deserialized[R]])(implicit ec: E
     }
 
   private lazy val handleErrors: Future[Deserialized[R]] = underlying recover {
-    case error: Throwable => ConnectionError("Error when processing the future response", Some(error)).failureNel
+    case error: Throwable => ConnectionError("Error when processing the future response", Some(error)).failures
   }
 }
 
@@ -35,7 +35,7 @@ object XmlrpcResponse {
     Future.successful(value)
   }
 
-  implicit class SprayToXmlrpcResponse(underlying: Future[NodeSeq])(implicit ec: ExecutionContext) {
+  implicit class AkkaHttpToXmlrpcResponse(underlying: Future[NodeSeq])(implicit ec: ExecutionContext) {
     def asXmlrpcResponse[R: Datatype]: XmlrpcResponse[R] = XmlrpcResponse[R](underlying map readXmlResponse[R])
   }
 

--- a/src/main/scala/xmlrpc/protocol/BasicTypes.scala
+++ b/src/main/scala/xmlrpc/protocol/BasicTypes.scala
@@ -22,7 +22,7 @@ trait BasicTypes extends Protocol {
     override def deserialize(from: NodeSeq): Deserialized[Array[Byte]] =
       from \\ "value" headOption match {
         case Some(<value><base64>{content}</base64></value>) => content.text.getBytes.success
-        case _ => s"Expected base64 structure in $from".toError.failureNel
+        case _ => s"Expected base64 structure in $from".toError.failures
       }
   }
 
@@ -35,9 +35,9 @@ trait BasicTypes extends Protocol {
           try {
             ISO8601Format.parse(date.text).success
           } catch {
-            case e: Exception => DeserializationError(s"The date ${from.text} has not been parsed correctly", Some(e)).failureNel
+            case e: Exception => DeserializationError(s"The date ${from.text} has not been parsed correctly", Some(e)).failures
           }
-        case _ => s"Expected datetime structure in $from".toError.failureNel
+        case _ => s"Expected datetime structure in $from".toError.failures
       }
   }
 
@@ -49,7 +49,7 @@ trait BasicTypes extends Protocol {
         case Some(<value><double>{double}</double></value>) =>
           makeNumericConversion(_.toDouble, double.text)
 
-        case _ => "Expected double structure in $from".toError.failureNel
+        case _ => "Expected double structure in $from".toError.failures
       }
   }
 
@@ -64,7 +64,7 @@ trait BasicTypes extends Protocol {
         case Some(<value><i4>{integer}</i4></value>) =>
           makeNumericConversion(_.toInt, integer.text)
 
-        case _ => s"Expected int structure in $from".toError.failureNel
+        case _ => s"Expected int structure in $from".toError.failures
       }
   }
 
@@ -77,9 +77,9 @@ trait BasicTypes extends Protocol {
           logicalValue.text match {
             case "1" => true.success
             case "0" => false.success
-            case _ => "No logical value in boolean structure".toError.failureNel
+            case _ => "No logical value in boolean structure".toError.failures
           }
-        case _ => s"Expected boolean structure in $from".toError.failureNel
+        case _ => s"Expected boolean structure in $from".toError.failures
       }
   }
 
@@ -98,7 +98,7 @@ trait BasicTypes extends Protocol {
       from \\ "value" headOption match {
         case Some(<value><string>{content}</string></value>) => decodeSpecialCharacters(content.text).success
         case Some(<value>{content}</value>) => decodeSpecialCharacters(content.text).success
-        case _ => s"Expected string structure in $from".toError.failureNel
+        case _ => s"Expected string structure in $from".toError.failures
       }
     }
   }
@@ -112,7 +112,7 @@ trait BasicTypes extends Protocol {
     // If there is no param tag, then it is a void
     override def deserialize(from: NodeSeq): Deserialized[Empty] =
       from \\ "param" headOption match {
-        case Some(_) => s"Expected void (without any param tag) in $from".toError.failureNel
+        case Some(_) => s"Expected void (without any param tag) in $from".toError.failures
         case _ => Void.success
       }
   }
@@ -125,7 +125,7 @@ trait BasicTypes extends Protocol {
     override def deserialize(from: NodeSeq): Deserialized[Null] =
       from \\ "value" headOption match {
         case Some(<value><nil/></value>) => scala.xml.Null.success
-        case _ => s"Expected nil structure in $from".toError.failureNel
+        case _ => s"Expected nil structure in $from".toError.failures
       }
   }
 }

--- a/src/main/scala/xmlrpc/protocol/CollectionTypes.scala
+++ b/src/main/scala/xmlrpc/protocol/CollectionTypes.scala
@@ -21,7 +21,7 @@ trait CollectionTypes extends Protocol {
           (for { value <- array}
             yield fromXmlrpc[T](value)).toList.sequence[Deserialized, T]
 
-        case _ => "Expected array structure in $from".toError.failureNel
+        case _ => "Expected array structure in $from".toError.failures
       }
   }
 
@@ -46,7 +46,7 @@ trait CollectionTypes extends Protocol {
             .sequence[Deserialized, (String, T)]
             .map(_.toMap[String, T])
 
-        case _ => s"Expected struct in:\n$from".toError.failureNel
+        case _ => s"Expected struct in:\n$from".toError.failures
       }
   }
 }

--- a/src/main/scala/xmlrpc/protocol/Helpers.scala
+++ b/src/main/scala/xmlrpc/protocol/Helpers.scala
@@ -33,6 +33,6 @@ trait Helpers {
     Try(f(input)) match {
       case Success(convertedValue) => convertedValue.success
       case Failure(e) =>
-        DeserializationError(s"The value $input couldn't be converted to a ${implicitly[ClassTag[T]].runtimeClass.getSimpleName}", Some(e)).failureNel
+        DeserializationError(s"The value $input couldn't be converted to a ${implicitly[ClassTag[T]].runtimeClass.getSimpleName}", Some(e)).failures
     }
 }

--- a/src/test/scala/xmlrpc/XmlrpcConnection.scala
+++ b/src/test/scala/xmlrpc/XmlrpcConnection.scala
@@ -1,6 +1,7 @@
 package xmlrpc
 
 import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import org.scalatest.FunSpec
 import org.scalatest.concurrent.ScalaFutures
@@ -24,6 +25,7 @@ class XmlrpcConnection extends FunSpec with ScalaFutures {
 
   // Spray setup
   implicit val system = ActorSystem()
+  implicit val ma = ActorMaterializer()
   implicit val timeout = Timeout(5 seconds)
   import system.dispatcher
 


### PR DESCRIPTION
There was a problem with the scalaz upgrade and type inference. That's why I introduced an implicit class to extend AnyError and replaced failureNel.