### PR TITLE
Switch to using Java8 time, which is thread safe

### DIFF
--- a/src/main/scala/xmlrpc/protocol/DatetimeSpec.scala
+++ b/src/main/scala/xmlrpc/protocol/DatetimeSpec.scala
@@ -1,20 +1,19 @@
 package xmlrpc.protocol
 
 import java.text.SimpleDateFormat
-import java.util.{Date, TimeZone}
+import java.time.{LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatter
+import java.util.Date
 
 trait DatetimeSpec {
   /**
    * This is a pseudo ISO8601 timestamp because it lacks milliseconds and time zone
    * information. Specification in [[http://en.wikipedia.org/wiki/XML-RPC]].
    */
-  val ISO8601Format = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss")
+  val ISO8601Format = DateTimeFormatter.ofPattern("yyyyMMdd'T'HH:mm:ss")
 
   // If you want to change the timezone of the dates, just override this
-  val serverTimezone = TimeZone.getDefault
-
-  ISO8601Format.setTimeZone(serverTimezone)
-  ISO8601Format.setLenient(false)
+  val serverTimezone = ZoneId.systemDefault()
 
   def withoutMillis(date: Date): Date = {
     val dateTime = date.getTime


### PR DESCRIPTION
I encountered some really weird errors when doing some date parsing, turns out `SimpleDateFormat` is not thread safe, and may crash. So I converted the library to use Java8 time. 

Is it a fair assumption to expect Java 8 compliance, given that the main target is Scala 2.12?