### PR TITLE
Add Content-Type and optional credentials to requests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ description := "Module that gives full compatibility with XML-RPC for Scala"
 
 organization := "com.github.jvican"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+crossScalaVersions := Seq("2.11.8", "2.12.8")
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("releases"),
@@ -16,14 +16,16 @@ resolvers ++= Seq(
 )
 
 libraryDependencies ++= {
-  val scalazVersion = "7.2.8"
-  val akkaHttp = "10.0.2"
-  val scalaTestVersion = "3.0.1"
-  val shapelessVersion = "2.3.2"
+  val scalazVersion = "7.2.27"
+  val akkaHttp = "10.1.8"
+  val scalaTestVersion = "3.0.7"
+  val shapelessVersion = "2.3.3"
 
   Seq(
     "org.scalaz"             %% "scalaz-core"    % scalazVersion,
     "com.typesafe.akka"      %% "akka-http-xml"  % akkaHttp,
+    "com.typesafe.akka"      %% "akka-actor"     % "2.5.23",
+    "com.typesafe.akka"      %% "akka-stream"    % "2.5.23",
     "org.scalatest"          %% "scalatest"      % scalaTestVersion    % "test",
     "com.chuusai"            %% "shapeless"      % shapelessVersion
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.5")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0") 
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2") 
 

--- a/src/main/scala/xmlrpc/Xmlrpc.scala
+++ b/src/main/scala/xmlrpc/Xmlrpc.scala
@@ -48,7 +48,7 @@ object Xmlrpc {
 
 
     try {
-      (Http().singleRequest(Post(xmlrpcServer.uri, request)) ~> unmarshall[NodeSeq]).asXmlrpcResponse[R]
+      (Http().singleRequest(Post(xmlrpcServer.uri, request).mapEntity(_.withContentType(ContentTypes.`text/xml(UTF-8)`))) ~> unmarshall[NodeSeq]).asXmlrpcResponse[R]
     } catch {
       case t: Throwable => XmlrpcResponse(ConnectionError("An exception has been thrown by Spray", Some(t)).failures)
     }

--- a/src/main/scala/xmlrpc/Xmlrpc.scala
+++ b/src/main/scala/xmlrpc/Xmlrpc.scala
@@ -12,6 +12,7 @@ import xmlrpc.protocol._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
+import akka.http.scaladsl.model.headers.HttpCredentials
 
 /**
   * This is the client api to connect to the Xmlrpc server. A client can send any request
@@ -26,7 +27,7 @@ object Xmlrpc {
 
   import XmlrpcProtocol._
 
-  case class XmlrpcServer(fullAddress: String) {
+  case class XmlrpcServer(fullAddress: String, credentials: Option[HttpCredentials] = None) {
     def uri: Uri = Uri(fullAddress)
   }
 
@@ -43,12 +44,15 @@ object Xmlrpc {
       f.flatMap(Unmarshal(_).to[A])
 
 
-    val request: NodeSeq = writeXmlRequest(name, parameter)
-    val requestWithHeader: String = """<?xml version="1.0"?>""" + request.toString
-
+    val requestBody: NodeSeq = writeXmlRequest(name, parameter)
+    val requestBodyWithHeader: String = """<?xml version="1.0"?>""" + requestBody.toString
+    val request: HttpRequest = {
+      val base = Post(xmlrpcServer.uri, requestBody)
+      xmlrpcServer.credentials.map(base.addCredentials).getOrElse(base)
+    }
 
     try {
-      (Http().singleRequest(Post(xmlrpcServer.uri, request).mapEntity(_.withContentType(ContentTypes.`text/xml(UTF-8)`))) ~> unmarshall[NodeSeq]).asXmlrpcResponse[R]
+      (Http().singleRequest(request) ~> unmarshall[NodeSeq]).asXmlrpcResponse[R]
     } catch {
       case t: Throwable => XmlrpcResponse(ConnectionError("An exception has been thrown by Spray", Some(t)).failures)
     }


### PR DESCRIPTION
According to the XML-RPC spec:
> The Content-Type is text/xml.
I was getting errors for it being missing. 

I also added optional credentials, so that authenticated requests are possible.

If you prefer I can separate these two features in separate PRs.

This depends on https://github.com/jvican/xmlrpc/pull/11 